### PR TITLE
8. Небольшая оптимизация адаптера

### DIFF
--- a/app/src/main/java/softing/ubah4ukdev/moviesinfosearcher/ui/home/adapter/MoviesGroupAdapter.kt
+++ b/app/src/main/java/softing/ubah4ukdev/moviesinfosearcher/ui/home/adapter/MoviesGroupAdapter.kt
@@ -1,5 +1,6 @@
 package softing.ubah4ukdev.moviesinfosearcher.ui.home.adapter
 
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -22,6 +23,8 @@ class MoviesGroupAdapter(movieClickable: IMovieClickable) :
     private val movieGroups = ArrayList<MovieGroup>()
     private val iMovieClickable = movieClickable
 
+    private val adapters:ArrayList<MoviesAdapter> = arrayListOf()
+
     private val pool: RecyclerView.RecycledViewPool = RecyclerView.RecycledViewPool()
 
     fun addItems(movieGroupList: ArrayList<MovieGroup>) = movieGroups.addAll(movieGroupList)
@@ -36,18 +39,25 @@ class MoviesGroupAdapter(movieClickable: IMovieClickable) :
                 R.layout.item_movies_group,
                 parent,
                 false
-            )
+            ).also {
+                adapters.add(MoviesAdapter(iMovieClickable))
+                Log.d("movieLog","moviesAdapterCreate")
+            }
         )
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
         val move = movieGroups[position]
-        val moviesAdapter = MoviesAdapter(iMovieClickable).also {
-            it.addItems(movieGroups[position].movies)
-        }
+//        val moviesAdapter = MoviesAdapter(iMovieClickable).also {
+//            Log.d("movieLog","moviesAdapterCreate")
+//            it.addItems(movieGroups[position].movies)
+//        }
+
+        adapters[position].clear()
+        adapters[position].addItems(movieGroups[position].movies)
 
         with(holder) {
             groupName.text = move.group
-            moviesRV.adapter = moviesAdapter
+            moviesRV.adapter = adapters[position]
             moviesRV.setRecycledViewPool(pool)
         }
     }


### PR DESCRIPTION
 Переделано создание адаптеров в OnCreateViewHolder (т.к. при каждом bindViewHolder создается новый адаптер, это лишние расходы памяти, ресурсов и времени, а нужно создавать адаптер один раз, в onCreateViewHolder). Проверил с помощью логирования, адаптеры создаются каждый раз при переходе во фрагмент с списками фильмов. Но если перейти на детализацию фильма и потом вернуться в список фильмов, адаптеры заново уже не создаются, в отличие от старого способа реализации.